### PR TITLE
Support for HTML Input File for android - fix for issue #66 and #76

### DIFF
--- a/SampleApp/SampleApp.Droid/MainActivity.cs
+++ b/SampleApp/SampleApp.Droid/MainActivity.cs
@@ -9,23 +9,49 @@ using Android.Widget;
 using Android.OS;
 using Android.Webkit;
 using Xam.Plugin.WebView.Droid;
+using System.Collections.Concurrent;
 
 namespace SampleApp.Droid
 {
     [Activity(Label = "SampleApp", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-    public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+    public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity, IFormsWebViewMainActivity
     {
+        readonly ConcurrentDictionary<int, Action<Result, Intent>> _activityResultCallbacks = new ConcurrentDictionary<int, Action<Result, Intent>>();
+
         protected override void OnCreate(Bundle bundle)
         {
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;
 
             base.OnCreate(bundle);
-            
+
             FormsWebViewRenderer.Initialize();
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App());
+        }
+
+
+        public void RegisterActivityResultCallback(int requestCode, Action<Result, Intent> callback)
+        {
+            _activityResultCallbacks.TryAdd(requestCode, callback);
+        }
+
+        public void UnregisterActivityResultCallback(int requestCode)
+        {
+            Action<Result, Intent> callback;
+            _activityResultCallbacks.TryRemove(requestCode, out callback);
+
+            callback = null;
+        }
+
+        protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
+        {
+            base.OnActivityResult(requestCode, resultCode, data);
+
+            Action<Result, Intent> callback;
+            if (_activityResultCallbacks.TryGetValue(requestCode, out callback))
+                callback(resultCode, data);
         }
     }
 }

--- a/SampleApp/SampleApp/MainPage.xaml.cs
+++ b/SampleApp/SampleApp/MainPage.xaml.cs
@@ -178,6 +178,13 @@ namespace SampleApp
                 Title = "Cookie test",
                 Detail = "Clear cookies in the web view"
             });
+
+            Items.Add(new SelectionItem()
+            {
+                Identifier = 22,
+                Title = "FileUpload",
+                Detail = "File upload support."
+            });
         }
 
         async void OnItemSelected(object sender, SelectedItemChangedEventArgs e)
@@ -272,6 +279,10 @@ namespace SampleApp
 
                 case 21:
                     await ((NavigationPage)Application.Current.MainPage).PushAsync(new ClearCookieSample());
+                    break;
+
+                case 22:
+                    await ((NavigationPage)Application.Current.MainPage).PushAsync(new UploadSample());
                     break;
 
                 default:

--- a/SampleApp/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp/SampleApp.csproj
@@ -107,6 +107,9 @@
     <Compile Include="Samples\EmailDataSample.xaml.cs">
       <DependentUpon>EmailDataSample.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Samples\UploadSample.xaml.cs">
+      <DependentUpon>UploadSample.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -263,6 +266,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Samples\ClearCookieSample.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Samples\UploadSample.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/SampleApp/SampleApp/Samples/UploadSample.xaml
+++ b/SampleApp/SampleApp/Samples/UploadSample.xaml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:webview="clr-namespace:Xam.Plugin.WebView.Abstractions;assembly=Xam.Plugin.WebView.Abstractions"
+             x:Class="SampleApp.Samples.UploadSample"
+             Title="FileUpload">
+
+    <webview:FormsWebView x:Name="internetContent" ContentType="Internet"
+                      Source="http://anssiko.github.io/html-media-capture" />
+
+</ContentPage>

--- a/SampleApp/SampleApp/Samples/UploadSample.xaml.cs
+++ b/SampleApp/SampleApp/Samples/UploadSample.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace SampleApp.Samples
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class UploadSample : ContentPage
+    {
+        public UploadSample()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Xam.Plugin.WebView.Droid/FormsWebViewChromeClient.cs
+++ b/Xam.Plugin.WebView.Droid/FormsWebViewChromeClient.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-
 using Android.App;
 using Android.Content;
 using Android.OS;
@@ -10,12 +9,14 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.Webkit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
 
 namespace Xam.Plugin.WebView.Droid
 {
     public class FormsWebViewChromeClient : WebChromeClient
     {
-
+        private static int FILECHOOSER_RESULTCODE = 1;
         readonly WeakReference<FormsWebViewRenderer> Reference;
 
         public FormsWebViewChromeClient(FormsWebViewRenderer renderer)
@@ -23,5 +24,49 @@ namespace Xam.Plugin.WebView.Droid
             Reference = new WeakReference<FormsWebViewRenderer>(renderer);
         }
 
+        // For Android < 5.0
+        [Java.Interop.Export]
+        public void openFileChooser(IValueCallback filePathCallback, string acceptType, string capture)
+        {
+            Intent chooserIntent = new Intent(Intent.ActionGetContent);
+            chooserIntent.AddCategory(Intent.CategoryOpenable);
+            chooserIntent.SetType("*/*");
+            RegisterCustomFileUploadActivity(filePathCallback, chooserIntent);
+        }
+
+        // For Android > 5.0
+        [Android.Runtime.Register("onShowFileChooser", "(Landroid/webkit/WebView;Landroid/webkit/ValueCallback;Landroid/webkit/WebChromeClient$FileChooserParams;)Z", "GetOnShowFileChooser_Landroid_webkit_WebView_Landroid_webkit_ValueCallback_Landroid_webkit_WebChromeClient_FileChooserParams_Handler")]
+        public override bool OnShowFileChooser(global::Android.Webkit.WebView webView, IValueCallback filePathCallback, FileChooserParams fileChooserParams)
+        {
+            base.OnShowFileChooser(webView, filePathCallback, fileChooserParams);
+
+            var chooserIntent = fileChooserParams.CreateIntent();
+            RegisterCustomFileUploadActivity(filePathCallback, chooserIntent, fileChooserParams.Title);
+
+            return true;
+        }
+
+        private void RegisterCustomFileUploadActivity(IValueCallback filePathCallback, Intent chooserIntent, string title = "File Chooser")
+        {
+            if (Forms.Context is IFormsWebViewMainActivity)
+            {
+                var appActivity = Forms.Context as IFormsWebViewMainActivity;
+
+                Action<Result, Intent> callback = (resultCode, intentData) =>
+                {
+                    if (filePathCallback == null)
+                        return;
+
+                    var result = FileChooserParams.ParseResult((int)resultCode, intentData);
+                    filePathCallback.OnReceiveValue(result);
+
+                    appActivity.UnregisterActivityResultCallback(FILECHOOSER_RESULTCODE);
+                };
+
+                appActivity.RegisterActivityResultCallback(FILECHOOSER_RESULTCODE, callback);
+
+                ((FormsAppCompatActivity)Forms.Context).StartActivityForResult(Intent.CreateChooser(chooserIntent, title), FILECHOOSER_RESULTCODE);
+            }
+        }
     }
 }

--- a/Xam.Plugin.WebView.Droid/IFormsWebViewMainActivity.cs
+++ b/Xam.Plugin.WebView.Droid/IFormsWebViewMainActivity.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Android.Webkit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+namespace Xam.Plugin.WebView.Droid
+{
+    public interface IFormsWebViewMainActivity
+    {
+        void RegisterActivityResultCallback(int requestCode, Action<Result, Intent> callback);
+        void UnregisterActivityResultCallback(int requestCode);
+    }
+}

--- a/Xam.Plugin.WebView.Droid/Xam.Plugin.WebView.Droid.csproj
+++ b/Xam.Plugin.WebView.Droid/Xam.Plugin.WebView.Droid.csproj
@@ -92,6 +92,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FormsWebViewBridge.cs" />
+    <Compile Include="IFormsWebViewMainActivity.cs" />
     <Compile Include="FormsWebViewChromeClient.cs" />
     <Compile Include="FormsWebViewClient.cs" />
     <Compile Include="FormsWebViewRenderer.cs" />


### PR DESCRIPTION
I have looked at different solution for supporting HTML Input File and I came with a I clean solution which implements the interface IFormsWebViewMainActivity on MainActivity.cs in the Android project. It's also very nice that the solution is backward compatible because if the interface is not implemented then the app will not crash. One more great benefit with this solution is that it's more dynamic compared with other solutions I have seen. This means for example that the methods RegisterActivityResultCallback and UnRegisterActivityResultCallback  are not only isoleted to FILECHOOSER_RESULTCODE callbacks.

If you see any improvements just let me know and feel also free to modify the code as you like. I hope you can merge this to your solution soon because it will be really good to have this support.