### PR TITLE
Adding bindable property for current url

### DIFF
--- a/SampleApp/SampleApp/MainPage.xaml.cs
+++ b/SampleApp/SampleApp/MainPage.xaml.cs
@@ -178,6 +178,13 @@ namespace SampleApp
                 Title = "Cookie test",
                 Detail = "Clear cookies in the web view"
             });
+
+            Items.Add(new SelectionItem()
+            {
+                Identifier = 22,
+                Title = "Current URL",
+                Detail = "Bind to the current URL property"
+            });
         }
 
         async void OnItemSelected(object sender, SelectedItemChangedEventArgs e)
@@ -273,7 +280,9 @@ namespace SampleApp
                 case 21:
                     await ((NavigationPage)Application.Current.MainPage).PushAsync(new ClearCookieSample());
                     break;
-
+                case 22:
+                    await ((NavigationPage)Application.Current.MainPage).PushAsync(new CurrentUrlSample());
+                    break;
                 default:
                     break;
             }

--- a/SampleApp/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp/SampleApp.csproj
@@ -44,6 +44,9 @@
     <Compile Include="Samples\BackgroundColorSample.xaml.cs">
       <DependentUpon>BackgroundColorSample.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Samples\CurrentUrlSample.xaml.cs">
+      <DependentUpon>CurrentUrlSample.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Samples\ClearCookieSample.xaml.cs">
       <DependentUpon>ClearCookieSample.xaml</DependentUpon>
     </Compile>
@@ -263,6 +266,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Samples\ClearCookieSample.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Samples\CurrentUrlSample.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/SampleApp/SampleApp/Samples/CurrentUrlSample.xaml
+++ b/SampleApp/SampleApp/Samples/CurrentUrlSample.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:webview="clr-namespace:Xam.Plugin.WebView.Abstractions;assembly=Xam.Plugin.WebView.Abstractions"
+             x:Class="SampleApp.Samples.CurrentUrlSample">
+    <StackLayout Orientation="Vertical">
+        <Label Text="Current URL:" />
+        <Label Text="{Binding Source={x:Reference localContent},Path=CurrentUrl}" />
+        <webview:FormsWebView x:Name="localContent"
+                              VerticalOptions="FillAndExpand"
+                              HorizontalOptions="FillAndExpand"
+                              Source="https://github.com/SKLn-Rad/Xam.Plugin.Webview" />
+
+    </StackLayout>
+</ContentPage>

--- a/SampleApp/SampleApp/Samples/CurrentUrlSample.xaml.cs
+++ b/SampleApp/SampleApp/Samples/CurrentUrlSample.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace SampleApp.Samples
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CurrentUrlSample : ContentPage
+    {
+        public CurrentUrlSample()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Xam.Plugin.WebView.Abstractions/FormsWebView.Static.cs
+++ b/Xam.Plugin.WebView.Abstractions/FormsWebView.Static.cs
@@ -32,6 +32,11 @@ namespace Xam.Plugin.WebView.Abstractions
         public static readonly BindableProperty BaseUrlProperty = BindableProperty.Create(nameof(BaseUrl), typeof(string), typeof(FormsWebView));
 
         /// <summary>
+        /// A bindable property cor the CurrentUrl property.
+        /// </summary>
+        public static readonly BindableProperty CurrentUrlProperty = BindableProperty.Create(nameof(CurrentUrl), typeof(string), typeof(FormsWebView));
+
+        /// <summary>
         /// A bindable property for the CanGoBack property.
         /// </summary>
         public static readonly BindableProperty CanGoBackProperty = BindableProperty.Create(nameof(CanGoBack), typeof(bool), typeof(FormsWebView), false);

--- a/Xam.Plugin.WebView.Abstractions/FormsWebView.cs
+++ b/Xam.Plugin.WebView.Abstractions/FormsWebView.cs
@@ -83,7 +83,7 @@ namespace Xam.Plugin.WebView.Abstractions
         /// </summary>
         public string Source
         {
-            get => (string) GetValue(SourceProperty);
+            get => (string)GetValue(SourceProperty);
             set => SetValue(SourceProperty, value);
         }
 
@@ -100,12 +100,18 @@ namespace Xam.Plugin.WebView.Abstractions
             set { SetValue(BaseUrlProperty, value); }
         }
 
+        public string CurrentUrl
+        {
+            get { return (string)GetValue(CurrentUrlProperty); }
+            set { SetValue(CurrentUrlProperty, value); }
+        }
+
         /// <summary>
         /// Opt in and out of global callbacks
         /// </summary>
         public bool EnableGlobalCallbacks
         {
-            get => (bool) GetValue(EnableGlobalCallbacksProperty);
+            get => (bool)GetValue(EnableGlobalCallbacksProperty);
             set => SetValue(EnableGlobalCallbacksProperty, value);
         }
 
@@ -114,7 +120,7 @@ namespace Xam.Plugin.WebView.Abstractions
         /// </summary>
         public bool EnableGlobalHeaders
         {
-            get => (bool) GetValue(EnableGlobalHeadersProperty);
+            get => (bool)GetValue(EnableGlobalHeadersProperty);
             set => SetValue(EnableGlobalHeadersProperty, value);
         }
 
@@ -132,7 +138,7 @@ namespace Xam.Plugin.WebView.Abstractions
         /// </summary>
         public bool CanGoBack
         {
-            get => (bool) GetValue(CanGoBackProperty);
+            get => (bool)GetValue(CanGoBackProperty);
             internal set => SetValue(CanGoBackProperty, value);
         }
 
@@ -141,13 +147,13 @@ namespace Xam.Plugin.WebView.Abstractions
         /// </summary>
         public bool CanGoForward
         {
-            get => (bool) GetValue(CanGoForwardProperty);
+            get => (bool)GetValue(CanGoForwardProperty);
             internal set => SetValue(CanGoForwardProperty, value);
         }
 
         public bool UseWideViewPort
         {
-            get => (bool) GetValue(UseWideViewPortProperty);
+            get => (bool)GetValue(UseWideViewPortProperty);
             set => SetValue(UseWideViewPortProperty, value);
         }
 
@@ -186,7 +192,8 @@ namespace Xam.Plugin.WebView.Abstractions
         /// Clearing all cookies.
         /// For UWP, all temporary browser data will be cleared.
         /// </summary>
-        public async Task ClearCookiesAsync() {
+        public async Task ClearCookiesAsync()
+        {
             if (OnClearCookiesRequested != null)
                 await OnClearCookiesRequested.Invoke();
         }
@@ -260,7 +267,7 @@ namespace Xam.Plugin.WebView.Abstractions
             // By default, we only attempt to offload valid Uris with none http/s schemes
             bool validUri = Uri.TryCreate(uri, UriKind.Absolute, out Uri uriResult);
             bool validScheme = false;
-            
+
             if (validUri)
                 validScheme = uriResult.Scheme.StartsWith("http") || uriResult.Scheme.StartsWith("file");
 
@@ -292,7 +299,7 @@ namespace Xam.Plugin.WebView.Abstractions
         internal void HandleScriptReceived(string data)
         {
             if (string.IsNullOrWhiteSpace(data)) return;
-            
+
             var action = JsonConvert.DeserializeObject<ActionEvent>(data);
 
             // Decode

--- a/Xam.Plugin.WebView.Abstractions/IFormsWebView.cs
+++ b/Xam.Plugin.WebView.Abstractions/IFormsWebView.cs
@@ -22,6 +22,8 @@ namespace Xam.Plugin.WebView.Abstractions
 
         string BaseUrl { get; set; }
 
+        string CurrentUrl { get; set; }
+
         bool EnableGlobalCallbacks { get; set; }
 
         bool EnableGlobalHeaders { get; set; }

--- a/Xam.Plugin.WebView.Droid/FormsWebViewClient.cs
+++ b/Xam.Plugin.WebView.Droid/FormsWebViewClient.cs
@@ -35,12 +35,11 @@ namespace Xam.Plugin.WebView.Droid
             if (Reference == null || !Reference.TryGetTarget(out FormsWebViewRenderer renderer)) return;
             if (renderer.Element == null) return;
 
-            renderer.Element.HandleNavigationError((int) error.ErrorCode);
+            renderer.Element.HandleNavigationError((int)error.ErrorCode);
             renderer.Element.HandleNavigationCompleted(request.Url.ToString());
             renderer.Element.Navigating = false;
         }
-
-        public override WebResourceResponse ShouldInterceptRequest(Android.Webkit.WebView view, IWebResourceRequest request)
+        public override bool ShouldOverrideUrlLoading(Android.Webkit.WebView view, IWebResourceRequest request)
         {
             if (Reference == null || !Reference.TryGetTarget(out FormsWebViewRenderer renderer)) goto EndShouldInterceptRequest;
             if (renderer.Element == null) goto EndShouldInterceptRequest;
@@ -57,10 +56,11 @@ namespace Xam.Plugin.WebView.Droid
 
                     view.StopLoading();
                 });
+                return true;
             }
 
             EndShouldInterceptRequest:
-            return base.ShouldInterceptRequest(view, request);
+            return base.ShouldOverrideUrlLoading(view, request);
         }
 
         void CheckResponseValidity(Android.Webkit.WebView view, string url)

--- a/Xam.Plugin.WebView.Droid/FormsWebViewRenderer.cs
+++ b/Xam.Plugin.WebView.Droid/FormsWebViewRenderer.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xam.Plugin.WebView.Abstractions;
+using Xam.Plugin.WebView.Abstractions.Delegates;
 using Xam.Plugin.WebView.Abstractions.Enumerations;
 using Xam.Plugin.WebView.Droid;
 using Xamarin.Forms;
@@ -64,6 +65,7 @@ namespace Xam.Plugin.WebView.Droid
             element.OnBackRequested += OnBackRequested;
             element.OnForwardRequested += OnForwardRequested;
             element.OnRefreshRequested += OnRefreshRequested;
+            element.OnNavigationStarted += SetCurrentUrl;
 
             SetSource();
         }
@@ -76,6 +78,7 @@ namespace Xam.Plugin.WebView.Droid
             element.OnBackRequested -= OnBackRequested;
             element.OnForwardRequested -= OnForwardRequested;
             element.OnRefreshRequested -= OnRefreshRequested;
+            element.OnNavigationStarted -= SetCurrentUrl;
 
             element.Dispose();
         }
@@ -97,7 +100,6 @@ namespace Xam.Plugin.WebView.Droid
             webView.SetBackgroundColor(Android.Graphics.Color.Transparent);
 
             FormsWebView.CallbackAdded += OnCallbackAdded;
-
             SetNativeControl(webView);
             OnControlChanged?.Invoke(this, webView);
         }
@@ -264,6 +266,15 @@ namespace Xam.Plugin.WebView.Droid
             }
 
             Control.LoadUrl(Element.Source, headers);
+        }
+
+
+        private void SetCurrentUrl(object sender, DecisionHandlerDelegate e)
+        {
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                Element.CurrentUrl = Control.Url;
+            });
         }
     }
 }

--- a/Xam.Plugin.WebView.MacOS/FormsNavigationDelegate.cs
+++ b/Xam.Plugin.WebView.MacOS/FormsNavigationDelegate.cs
@@ -3,6 +3,7 @@ using Foundation;
 using WebKit;
 using Xam.Plugin.WebView.Abstractions;
 using AppKit;
+using Xamarin.Forms;
 
 namespace Xam.Plugin.WebView.MacOS
 {
@@ -77,5 +78,17 @@ namespace Xam.Plugin.WebView.MacOS
 			renderer.Element.Navigating = false;
 			renderer.Element.HandleContentLoaded();
 		}
-	}
+
+        [Foundation.Export("webView:didStartProvisionalNavigation:")]
+        [ObjCRuntime.BindingImpl(ObjCRuntime.BindingImplOptions.GeneratedCode | ObjCRuntime.BindingImplOptions.Optimizable)]
+        public virtual void DidStartProvisionalNavigation(WKWebView webView, WKNavigation navigation)
+        {
+            if (Reference == null || !Reference.TryGetTarget(out FormsWebViewRenderer renderer)) return;
+            if (renderer.Element == null) return;
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                renderer.Element.CurrentUrl = webView.Url.ToString();
+            });
+        }
+    }
 }

--- a/Xam.Plugin.WebView.MacOS/FormsWebViewRenderer.cs
+++ b/Xam.Plugin.WebView.MacOS/FormsWebViewRenderer.cs
@@ -54,7 +54,6 @@ namespace Xam.Plugin.WebView.MacOS
             element.OnBackRequested += OnBackRequested;
 			element.OnForwardRequested += OnForwardRequested;
 			element.OnRefreshRequested += OnRefreshRequested;
-            element.OnNavigationStarted += SetCurrentUrl;
 
             SetSource();
 		}
@@ -67,7 +66,6 @@ namespace Xam.Plugin.WebView.MacOS
             element.OnBackRequested -= OnBackRequested;
 			element.OnForwardRequested -= OnForwardRequested;
 			element.OnRefreshRequested -= OnRefreshRequested;
-            element.OnNavigationStarted -= SetCurrentUrl;
 
             element.Dispose();
 		}
@@ -240,13 +238,5 @@ namespace Xam.Plugin.WebView.MacOS
 			if (Control.CanGoBack)
 				Control.GoBack();
 		}
-
-        private void SetCurrentUrl(object sender, DecisionHandlerDelegate e)
-        {
-            Device.BeginInvokeOnMainThread(() =>
-            {
-                Element.CurrentUrl = Control.Url.ToString();
-            });
-        }
     }
 }

--- a/Xam.Plugin.WebView.MacOS/FormsWebViewRenderer.cs
+++ b/Xam.Plugin.WebView.MacOS/FormsWebViewRenderer.cs
@@ -5,8 +5,10 @@ using System.Threading.Tasks;
 using Foundation;
 using WebKit;
 using Xam.Plugin.WebView.Abstractions;
+using Xam.Plugin.WebView.Abstractions.Delegates;
 using Xam.Plugin.WebView.Abstractions.Enumerations;
 using Xam.Plugin.WebView.MacOS;
+using Xamarin.Forms;
 using Xamarin.Forms.Platform.MacOS;
 
 [assembly: Xamarin.Forms.ExportRenderer(typeof(FormsWebView), typeof(FormsWebViewRenderer))]
@@ -52,8 +54,9 @@ namespace Xam.Plugin.WebView.MacOS
             element.OnBackRequested += OnBackRequested;
 			element.OnForwardRequested += OnForwardRequested;
 			element.OnRefreshRequested += OnRefreshRequested;
+            element.OnNavigationStarted += SetCurrentUrl;
 
-			SetSource();
+            SetSource();
 		}
 
         void DestroyElement(FormsWebView element)
@@ -64,8 +67,9 @@ namespace Xam.Plugin.WebView.MacOS
             element.OnBackRequested -= OnBackRequested;
 			element.OnForwardRequested -= OnForwardRequested;
 			element.OnRefreshRequested -= OnRefreshRequested;
+            element.OnNavigationStarted -= SetCurrentUrl;
 
-			element.Dispose();
+            element.Dispose();
 		}
 
 		void SetupControl()
@@ -236,5 +240,13 @@ namespace Xam.Plugin.WebView.MacOS
 			if (Control.CanGoBack)
 				Control.GoBack();
 		}
+
+        private void SetCurrentUrl(object sender, DecisionHandlerDelegate e)
+        {
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                Element.CurrentUrl = Control.Url.ToString();
+            });
+        }
     }
 }

--- a/Xam.Plugin.WebView.UWP/FormsWebViewRenderer.cs
+++ b/Xam.Plugin.WebView.UWP/FormsWebViewRenderer.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 using Windows.Web.Http;
 using Xam.Plugin.WebView.Abstractions;
+using Xam.Plugin.WebView.Abstractions.Delegates;
 using Xam.Plugin.WebView.Abstractions.Enumerations;
 using Xam.Plugin.WebView.UWP;
+using Xamarin.Forms;
 using Xamarin.Forms.Platform.UWP;
 
 [assembly: ExportRenderer(typeof(FormsWebView), typeof(FormsWebViewRenderer))]
@@ -73,6 +76,7 @@ namespace Xam.Plugin.WebView.UWP
             Control.NavigationCompleted += OnNavigationCompleted;
             Control.DOMContentLoaded += OnDOMContentLoaded;
             Control.ScriptNotify += OnScriptNotify;
+            Control.LoadCompleted += SetCurrentUrl;
             Control.DefaultBackgroundColor = Windows.UI.Colors.Transparent;
 
             OnControlChanged?.Invoke(this, control);
@@ -248,5 +252,14 @@ namespace Xam.Plugin.WebView.UWP
 
             return Windows.UI.Color.FromArgb(Convert.ToByte(color.A * 255), Convert.ToByte(color.R * 255), Convert.ToByte(color.G * 255), Convert.ToByte(color.B * 255));
         }
+        private void SetCurrentUrl(object sender, Windows.UI.Xaml.Navigation.NavigationEventArgs e)
+        {
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                Element.CurrentUrl = e.Uri.ToString();
+            });
+        }
+
+
     }
 }

--- a/Xam.Plugin.WebView.iOS/FormsNavigationDelegate.cs
+++ b/Xam.Plugin.WebView.iOS/FormsNavigationDelegate.cs
@@ -3,6 +3,7 @@ using Foundation;
 using WebKit;
 using Xam.Plugin.WebView.Abstractions;
 using UIKit;
+using Xamarin.Forms;
 
 namespace Xam.Plugin.WebView.iOS
 {
@@ -87,6 +88,18 @@ namespace Xam.Plugin.WebView.iOS
             renderer.Element.CanGoForward = webView.CanGoForward;
             renderer.Element.Navigating = false;
             renderer.Element.HandleContentLoaded();
+        }
+
+        [Foundation.Export("webView:didStartProvisionalNavigation:")]
+        [ObjCRuntime.BindingImpl(ObjCRuntime.BindingImplOptions.GeneratedCode | ObjCRuntime.BindingImplOptions.Optimizable)]
+        public virtual void DidStartProvisionalNavigation(WKWebView webView, WKNavigation navigation)
+        {
+            if (Reference == null || !Reference.TryGetTarget(out FormsWebViewRenderer renderer)) return;
+            if (renderer.Element == null) return;
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                renderer.Element.CurrentUrl = webView.Url.ToString();
+            });
         }
     }
 }

--- a/Xam.Plugin.WebView.iOS/FormsWebViewRenderer.cs
+++ b/Xam.Plugin.WebView.iOS/FormsWebViewRenderer.cs
@@ -9,6 +9,8 @@ using Xam.Plugin.WebView.Abstractions.Enumerations;
 using Xam.Plugin.WebView.iOS;
 using Xamarin.Forms.Platform.iOS;
 using UIKit;
+using Xam.Plugin.WebView.Abstractions.Delegates;
+using Xamarin.Forms;
 
 [assembly: Xamarin.Forms.ExportRenderer(typeof(FormsWebView), typeof(FormsWebViewRenderer))]
 namespace Xam.Plugin.WebView.iOS


### PR DESCRIPTION
As mentioned in #85 there is no clean way to get the current URL. The Source will never change and the BaseUrl is not really used for http from what I understand. 

My initial thought was to add the URL as a parameter in the navigation events, but due to differences in when I could fetch this from the native component it had to be separate from those events. The implementation on both iOS and Android updates the URL very early, but on UWP i needed to hook it up to the `LoadCompleted` event. 

Another difference between the implementations is how the webview handles URL changes done from javascript. iOS seems to update this as well, but not Android and UWP. 