### PR TITLE
triggering android navigation events from url-loading instead of reso…

### DIFF
--- a/Xam.Plugin.WebView.Droid/FormsWebViewClient.cs
+++ b/Xam.Plugin.WebView.Droid/FormsWebViewClient.cs
@@ -35,7 +35,7 @@ namespace Xam.Plugin.WebView.Droid
             if (Reference == null || !Reference.TryGetTarget(out FormsWebViewRenderer renderer)) return;
             if (renderer.Element == null) return;
 
-            renderer.Element.HandleNavigationError((int) error.ErrorCode);
+            renderer.Element.HandleNavigationError((int)error.ErrorCode);
             renderer.Element.HandleNavigationCompleted(request.Url.ToString());
             renderer.Element.Navigating = false;
         }
@@ -76,32 +76,46 @@ namespace Xam.Plugin.WebView.Droid
                 });
             }
 
-            EndShouldInterceptRequest:
+        EndShouldInterceptRequest:
             return base.ShouldInterceptRequest(view, url);
         }
 
+
         public override bool ShouldOverrideUrlLoading(Android.Webkit.WebView view, IWebResourceRequest request)
         {
-            if (Reference == null || !Reference.TryGetTarget(out FormsWebViewRenderer renderer)) goto EndShouldInterceptRequest;
-            if (renderer.Element == null) goto EndShouldInterceptRequest;
-
-            string url = request.Url.ToString();
-            var response = renderer.Element.HandleNavigationStartRequest(url);
-
-            if (response.Cancel || response.OffloadOntoDevice)
-            {
-                Device.BeginInvokeOnMainThread(() =>
-                {
-                    if (response.OffloadOntoDevice)
-                        AttemptToHandleCustomUrlScheme(view, url);
-
-                    view.StopLoading();
-                });
+            if (DoesComponentWantToOverrideUrlLoading(view, request.Url.ToString()))
                 return true;
-            }
 
-            EndShouldInterceptRequest:
             return base.ShouldOverrideUrlLoading(view, request);
+        }
+
+        public override bool ShouldOverrideUrlLoading(Android.Webkit.WebView view, string url)
+        {
+            if (DoesComponentWantToOverrideUrlLoading(view, url))
+                return true;
+
+            return base.ShouldOverrideUrlLoading(view, url);
+        }
+
+        private bool DoesComponentWantToOverrideUrlLoading(Android.Webkit.WebView view, string url)
+        {
+            if (Reference != null && Reference.TryGetTarget(out FormsWebViewRenderer renderer) && renderer.Element != null)
+            {
+                var response = renderer.Element.HandleNavigationStartRequest(url);
+
+                if (response.Cancel || response.OffloadOntoDevice)
+                {
+                    Device.BeginInvokeOnMainThread(() =>
+                    {
+                        if (response.OffloadOntoDevice)
+                            AttemptToHandleCustomUrlScheme(view, url);
+
+                        view.StopLoading();
+                    });
+                    return true;
+                }
+            }
+            return false;
         }
 
         void CheckResponseValidity(Android.Webkit.WebView view, string url)

--- a/Xam.Plugin.WebView.Droid/FormsWebViewClient.cs
+++ b/Xam.Plugin.WebView.Droid/FormsWebViewClient.cs
@@ -40,7 +40,7 @@ namespace Xam.Plugin.WebView.Droid
             renderer.Element.Navigating = false;
         }
 
-        public override WebResourceResponse ShouldInterceptRequest(Android.Webkit.WebView view, IWebResourceRequest request)
+        public override bool ShouldOverrideUrlLoading(Android.Webkit.WebView view, IWebResourceRequest request)
         {
             if (Reference == null || !Reference.TryGetTarget(out FormsWebViewRenderer renderer)) goto EndShouldInterceptRequest;
             if (renderer.Element == null) goto EndShouldInterceptRequest;
@@ -57,10 +57,11 @@ namespace Xam.Plugin.WebView.Droid
 
                     view.StopLoading();
                 });
+                return true;
             }
 
             EndShouldInterceptRequest:
-            return base.ShouldInterceptRequest(view, request);
+            return base.ShouldOverrideUrlLoading(view, request);
         }
 
         void CheckResponseValidity(Android.Webkit.WebView view, string url)


### PR DESCRIPTION
The current behavior of the `OnNavigationStarted` is not the same on iOS and Android due to use of `ShouldInterceptRequest`. This method is triggered whenever a request of any type is performed, and is not limited to navigation. Could be related to #63 

Let's say we try to limit the navigation in the webview to a specific domain and open a browser if the user navigates away.
```
        private void OnNavigationStarted(object sender, DecisionHandlerDelegate e)
        {
            if (!string.IsNullOrEmpty(e.Uri) && !e.Uri.StartsWith("https://www.mywebsite.com"))
            {
                e.OffloadOntoDevice = true;
                // or just cancel the navigation
               // e.Cancel == true;
            }
        }
```
On iOS this will work, but on Android the OnNavigationStarted event is triggered on all requests, so all calls to google analytics, loading of external resources, images etc is regarded a navigation and will be offloaded to the device. Using cancel and offloadontodevice flags on resource loading often breaks the site, so even if we successfully opens the external website in the device browser, when the user navigates back to the app, the webveiw navigation is broken and scroll behaves weird. 

Using `ShouldOverrideUrlLoading` instead will trigger the FormsWebView.OnNavigationStarted only when a navigation occured

