### PR TITLE
Fixes #116 - Droid: InjectJavascriptAsync returns result of a different call

### DIFF
--- a/SampleApp/SampleApp/MainPage.xaml.cs
+++ b/SampleApp/SampleApp/MainPage.xaml.cs
@@ -178,6 +178,13 @@ namespace SampleApp
                 Title = "Cookie test",
                 Detail = "Clear cookies in the web view"
             });
+
+            Items.Add(new SelectionItem()
+            {
+                Identifier = 22,
+                Title = "Parallel InjectJavascriptAsync invocations test",
+                Detail = "Verifies that parallel InjectJavascriptAsync invocations that return out of order still get the correct corresponding results"
+            });
         }
 
         async void OnItemSelected(object sender, SelectedItemChangedEventArgs e)
@@ -272,6 +279,10 @@ namespace SampleApp
 
                 case 21:
                     await ((NavigationPage)Application.Current.MainPage).PushAsync(new ClearCookieSample());
+                    break;
+
+                case 22:
+                    await ((NavigationPage)Application.Current.MainPage).PushAsync(new TestParallelInjectJavascriptAsyncInvocationsSample());
                     break;
 
                 default:

--- a/SampleApp/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp/SampleApp.csproj
@@ -101,6 +101,9 @@
     <Compile Include="Samples\SourceSwapSample.xaml.cs">
       <DependentUpon>SourceSwapSample.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Samples\TestParallelInjectJavascriptAsyncInvocationsSample.xaml.cs">
+      <DependentUpon>TestParallelInjectJavascriptAsyncInvocationsSample.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Samples\StringDataSample.xaml.cs">
       <DependentUpon>StringDataSample.xaml</DependentUpon>
     </Compile>
@@ -263,6 +266,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Samples\ClearCookieSample.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Samples\TestParallelInjectJavascriptAsyncInvocationsSample.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/SampleApp/SampleApp/Samples/TestParallelInjectJavascriptAsyncInvocationsSample.xaml
+++ b/SampleApp/SampleApp/Samples/TestParallelInjectJavascriptAsyncInvocationsSample.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:webview="clr-namespace:Xam.Plugin.WebView.Abstractions;assembly=Xam.Plugin.WebView.Abstractions"
+             Title="String Data"
+             x:Class="SampleApp.Samples.TestParallelInjectJavascriptAsyncInvocationsSample">
+
+    <StackLayout>
+        <Button
+            Text="Verify parallel calls return correct results"
+            Clicked="Button_OnClicked"
+            />
+        <webview:FormsWebView x:Name="stringContent" ContentType="StringData" />
+    </StackLayout>
+
+  </ContentPage>

--- a/SampleApp/SampleApp/Samples/TestParallelInjectJavascriptAsyncInvocationsSample.xaml.cs
+++ b/SampleApp/SampleApp/Samples/TestParallelInjectJavascriptAsyncInvocationsSample.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace SampleApp.Samples
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class TestParallelInjectJavascriptAsyncInvocationsSample : ContentPage
+    {
+        public TestParallelInjectJavascriptAsyncInvocationsSample()
+        {
+            InitializeComponent();
+            stringContent.Source = @"
+<!doctype html>
+<html>
+    <body><h1>This is a HTML string</h1></body>
+</html>
+            ";
+        }
+
+        private async void Button_OnClicked(object sender, EventArgs e)
+        {
+            const string invocation1ExpectedResult = "Invocation1";
+            const string invocation2ExpectedResult = "Invocation2";
+            var invocation1Task = stringContent.InjectJavascriptAsync($@"
+var delay = 3000; /* 3 seconds */
+var start = new Date().getTime();
+while (new Date().getTime() < start + delay);
+'{invocation1ExpectedResult}'");
+            var invocation2Task = stringContent.InjectJavascriptAsync($"'{invocation2ExpectedResult}'");
+
+            var invocation1Result = await invocation1Task;
+            var invocation2Result = await invocation2Task;
+            var didPass =
+                invocation1Result == invocation1ExpectedResult &&
+                invocation2Result == invocation2ExpectedResult;
+
+            await DisplayAlert("Parallel invocations test result",
+                (didPass
+                    ? "PASSED"
+                    : $"FAILED")
+                + $"\r\n\r\ninvocation1Result: {invocation1Result}\r\ninvocation2Result: {invocation2Result}",
+                "OK");
+        }
+    }
+}


### PR DESCRIPTION
1. added sample page which tests this behavior
2. [Droid] modified FormsWebViewRenderer to create a new instance of JavascriptValueCallback for each call to InjectJavascriptAsync