### PR TITLE
Support Html File Input

### DIFF
--- a/SampleApp/SampleApp.Droid/MainActivity.cs
+++ b/SampleApp/SampleApp.Droid/MainActivity.cs
@@ -13,7 +13,7 @@ using Xam.Plugin.WebView.Droid;
 namespace SampleApp.Droid
 {
     [Activity(Label = "SampleApp", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-    public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+    public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity, IMainActivityWithStarting
     {
         protected override void OnCreate(Bundle bundle)
         {
@@ -26,6 +26,22 @@ namespace SampleApp.Droid
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App());
+        }
+
+        private Action<int, Result, Intent> _resultCallback;
+        public void StartActivity(Intent intent, int requestCode, Action<int, Result, Intent> resultCallback)
+        {
+            _resultCallback = resultCallback;
+            StartActivityForResult(intent, requestCode);
+        }
+        protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
+        {
+            base.OnActivityResult(requestCode, resultCode, data);
+            if (_resultCallback != null)
+            {
+                _resultCallback(requestCode, resultCode, data);
+                _resultCallback = null;
+            }
         }
     }
 }

--- a/Xam.Plugin.WebView.Droid/FormsWebViewChromeClient.cs
+++ b/Xam.Plugin.WebView.Droid/FormsWebViewChromeClient.cs
@@ -10,12 +10,14 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.Webkit;
+using Xamarin.Forms.Platform.Android;
 
 namespace Xam.Plugin.WebView.Droid
 {
     public class FormsWebViewChromeClient : WebChromeClient
     {
-
+        private IValueCallback mUploadMessage;
+        private static int FILECHOOSER_RESULTCODE = 1;
         readonly WeakReference<FormsWebViewRenderer> Reference;
 
         public FormsWebViewChromeClient(FormsWebViewRenderer renderer)
@@ -23,5 +25,30 @@ namespace Xam.Plugin.WebView.Droid
             Reference = new WeakReference<FormsWebViewRenderer>(renderer);
         }
 
+        /* 
+         * below lines for fixing issue #66: Not support HTML Input File
+         * reference this workaround: https://forums.xamarin.com/discussion/62284/input-type-file-doesnt-work-on-xamarin-forms-webview-androidhome.firefoxchina.cn
+         */
+        private void OnActivityResult(int requestCode, Result resultCode, Intent data)
+        {
+            if (requestCode == FILECHOOSER_RESULTCODE)
+            {
+                if (null == mUploadMessage)
+                    return;
+                mUploadMessage.OnReceiveValue(WebChromeClient.FileChooserParams.ParseResult((int)resultCode, data));
+                mUploadMessage = null;
+            }
+        }
+        
+        [Android.Runtime.Register("onShowFileChooser", "(Landroid/webkit/WebView;Landroid/webkit/ValueCallback;Landroid/webkit/WebChromeClient$FileChooserParams;)Z", "GetOnShowFileChooser_Landroid_webkit_WebView_Landroid_webkit_ValueCallback_Landroid_webkit_WebChromeClient_FileChooserParams_Handler")]
+        public override bool OnShowFileChooser(Android.Webkit.WebView webView, IValueCallback filePathCallback, FileChooserParams fileChooserParams)
+        {
+            var appActivity = Xamarin.Forms.Forms.Context as IMainActivityWithStarting;
+            mUploadMessage = filePathCallback;
+            Intent chooserIntent = fileChooserParams.CreateIntent();
+            appActivity.StartActivity(chooserIntent, FILECHOOSER_RESULTCODE, OnActivityResult);
+            //return base.OnShowFileChooser (webView, filePathCallback, fileChooserParams);
+            return true;
+        }
     }
 }

--- a/Xam.Plugin.WebView.Droid/IMainActivityWithStarting.cs
+++ b/Xam.Plugin.WebView.Droid/IMainActivityWithStarting.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+namespace Xam.Plugin.WebView.Droid
+{
+    public interface IMainActivityWithStarting
+    {
+        void StartActivity(Intent intent, int requestCode, Action<int, Result, Intent> resultCallback);
+    }
+}

--- a/Xam.Plugin.WebView.Droid/Xam.Plugin.WebView.Droid.csproj
+++ b/Xam.Plugin.WebView.Droid/Xam.Plugin.WebView.Droid.csproj
@@ -95,6 +95,7 @@
     <Compile Include="FormsWebViewChromeClient.cs" />
     <Compile Include="FormsWebViewClient.cs" />
     <Compile Include="FormsWebViewRenderer.cs" />
+    <Compile Include="IMainActivityWithStarting.cs" />
     <Compile Include="JavascriptValueCallback.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
resolve issue #66 with [workaround](https://forums.xamarin.com/discussion/62284/input-type-file-doesnt-work-on-xamarin-forms-webview-androidhome.firefoxchina.cn)